### PR TITLE
change config for SE 1.3 as there is no samplesCNVit.txt made anymore

### DIFF
--- a/config/config_gen01.yaml
+++ b/config/config_gen01.yaml
@@ -346,7 +346,7 @@ pipelines:
                   ]
     sample_not_expected_files: []
     run_sample_expected_files: ['CNVKit/*_common.vcf']
-    run_expected_files: ['combined_QC.txt', 'samplesCNVKit.txt']
+    run_expected_files: ['combined_QC.txt', 'sampleVCFs.txt']
     run_not_expected_files: ['*.bed']
 
 


### PR DESCRIPTION
change config to fix bug where software thought SE 1. had not finished in valid state due to error in config.

