### PR TITLE
Adding new NovaSeq for WES QC

### DIFF
--- a/qc_database/management/commands/update_database.py
+++ b/qc_database/management/commands/update_database.py
@@ -195,7 +195,7 @@ class Command(BaseCommand):
 					
 								min_q30_score = 0.75
 		
-							elif str(run_obj.instrument) == 'A00748':
+							elif str(run_obj.instrument) == 'A00748' or str(run_obj.instrument) == 'A01771':
 			
 								min_q30_score = 0.85
 					


### PR DESCRIPTION
Adding in name of new NovaSeq sequencer for the conditional statement which sets the Q30 cut off for WES based on the sequencer. 