### PR TITLE
changed cnv cutoff in config

### DIFF
--- a/config/config_gen01.yaml
+++ b/config/config_gen01.yaml
@@ -186,7 +186,7 @@ pipelines:
     min_q30_score: 0.75
     contamination_cutoff: 0.10
     ntc_contamination_cutoff: 10
-    max_cnvs_called_cutoff: 300
+    max_cnvs_called_cutoff: 170
     min_sensitivity: 0.95
     min_fastq_size: 1000000
     min_variants: 50000
@@ -208,7 +208,7 @@ pipelines:
     min_q30_score: 0.75
     contamination_cutoff: 0.10
     ntc_contamination_cutoff: 10
-    max_cnvs_called_cutoff: 300
+    max_cnvs_called_cutoff: 170
     min_sensitivity: 0.95
     min_fastq_size: 1000000
     min_variants: 50000


### PR DESCRIPTION
As discussed - changed the max CNVs called cutoff in the config to 170 (mean of normal samples + 3 standard deviations - should cover 99.7% of samples).