### PR TITLE
CNV Metrics for WGS

### DIFF
--- a/config/config_gen01.yaml
+++ b/config/config_gen01.yaml
@@ -44,7 +44,7 @@ pipelines:
 
   DragenWGS-development-WGS:
     results_dir: '/mnt/wren_results/results/'
-    qc_checks: [pct_q30, variant_check, contamination, ntc_contamination, sex_match, titv, coverage, relatedness]
+    qc_checks: [pct_q30, variant_check, contamination, ntc_contamination, sex_match, titv, coverage, relatedness, min_average_coverage, max_cnv_calls]
     min_q30_score: 0.75
     contamination_cutoff: 0.025
     ntc_contamination_cutoff: 10
@@ -58,6 +58,8 @@ pipelines:
     max_relatedness_unrelated: 0.02
     max_relatedness_between_parents: 0.02
     max_child_parent_relatedness: 0.4
+    min_average_coverage: 30
+    max_cnvs_called_cutoff: 200
     sample_expected_files: ['*.cram',
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']
@@ -73,7 +75,7 @@ pipelines:
 
   DragenWGS-master-WGS:
     results_dir: '/mnt/wren_results/results/'
-    qc_checks: [pct_q30, variant_check, contamination, ntc_contamination, sex_match, titv, coverage, relatedness]
+    qc_checks: [pct_q30, variant_check, contamination, ntc_contamination, sex_match, titv, coverage, relatedness, min_average_coverage, max_cnv_calls]
     min_q30_score: 0.75
     contamination_cutoff: 0.025
     ntc_contamination_cutoff: 10
@@ -87,6 +89,8 @@ pipelines:
     max_relatedness_unrelated: 0.02
     max_relatedness_between_parents: 0.02
     max_child_parent_relatedness: 0.4
+    min_average_coverage: 30
+    max_cnvs_called_cutoff: 200
     sample_expected_files: ['*.cram',
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']
@@ -102,7 +106,7 @@ pipelines:
 
   DragenWGS-development-FastWGS:
     results_dir: '/mnt/wren_results/results/'
-    qc_checks: [pct_q30, variant_check, contamination, ntc_contamination, sex_match, titv, coverage, relatedness]
+    qc_checks: [pct_q30, variant_check, contamination, ntc_contamination, sex_match, titv, coverage, relatedness, min_average_coverage, max_cnv_calls]
     min_q30_score: 0.75
     contamination_cutoff: 0.025
     ntc_contamination_cutoff: 10
@@ -116,6 +120,8 @@ pipelines:
     max_relatedness_unrelated: 0.02
     max_relatedness_between_parents: 0.02
     max_child_parent_relatedness: 0.4
+    min_average_coverage: 30
+    max_cnvs_called_cutoff: 200
     sample_expected_files: ['*.cram',
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']
@@ -131,7 +137,7 @@ pipelines:
 
   DragenWGS-master-FastWGS:
     results_dir: '/mnt/wren_results/results/'
-    qc_checks: [pct_q30, variant_check, contamination, ntc_contamination, sex_match, titv, coverage, relatedness]
+    qc_checks: [pct_q30, variant_check, contamination, ntc_contamination, sex_match, titv, coverage, relatedness, min_average_coverage, max_cnv_calls]
     min_q30_score: 0.75
     contamination_cutoff: 0.025
     ntc_contamination_cutoff: 10
@@ -145,6 +151,8 @@ pipelines:
     max_relatedness_unrelated: 0.02
     max_relatedness_between_parents: 0.02
     max_child_parent_relatedness: 0.4
+    min_average_coverage: 30
+    max_cnvs_called_cutoff: 200
     sample_expected_files: ['*.cram',
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']
@@ -181,8 +189,8 @@ pipelines:
     max_variants: 500
 
   DragenGE-master-NonocusWES38:
-    results_dir:  '/mnt/wren_results/results/'
     qc_checks: [pct_q30, variant_check, contamination, ntc_contamination, sex_match, coverage, relatedness, max_cnv_calls]
+    results_dir:  '/mnt/wren_results/results/'
     min_q30_score: 0.75
     contamination_cutoff: 0.10
     ntc_contamination_cutoff: 10

--- a/config/config_gen01.yaml
+++ b/config/config_gen01.yaml
@@ -59,7 +59,7 @@ pipelines:
     max_relatedness_between_parents: 0.02
     max_child_parent_relatedness: 0.4
     min_average_coverage: 30
-    max_cnvs_called_cutoff: 200
+    max_cnvs_called_cutoff: 300
     sample_expected_files: ['*.cram',
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']
@@ -90,7 +90,7 @@ pipelines:
     max_relatedness_between_parents: 0.02
     max_child_parent_relatedness: 0.4
     min_average_coverage: 30
-    max_cnvs_called_cutoff: 200
+    max_cnvs_called_cutoff: 300
     sample_expected_files: ['*.cram',
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']
@@ -121,7 +121,7 @@ pipelines:
     max_relatedness_between_parents: 0.02
     max_child_parent_relatedness: 0.4
     min_average_coverage: 30
-    max_cnvs_called_cutoff: 200
+    max_cnvs_called_cutoff: 300
     sample_expected_files: ['*.cram',
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']
@@ -152,7 +152,7 @@ pipelines:
     max_relatedness_between_parents: 0.02
     max_child_parent_relatedness: 0.4
     min_average_coverage: 30
-    max_cnvs_called_cutoff: 200
+    max_cnvs_called_cutoff: 300
     sample_expected_files: ['*.cram',
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']

--- a/config/config_local.yaml
+++ b/config/config_local.yaml
@@ -16,6 +16,8 @@ pipelines:
     max_relatedness_unrelated: 0.02
     max_relatedness_between_parents: 0.02
     max_child_parent_relatedness: 0.4
+    min_average_coverage: 30
+    max_cnvs_called_cutoff: 300
     sample_expected_files: ['*.cram',
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']
@@ -44,6 +46,8 @@ pipelines:
     max_relatedness_unrelated: 0.02
     max_relatedness_between_parents: 0.02
     max_child_parent_relatedness: 0.4
+    min_average_coverage: 30
+    max_cnvs_called_cutoff: 300
     sample_expected_files: ['*.cram',
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']

--- a/pipelines/dragen_pipelines.py
+++ b/pipelines/dragen_pipelines.py
@@ -601,5 +601,9 @@ class DragenWGS:
 				parsed_cnv_metrics = parsers.parse_dragen_cnv_metrics_file(cnv_file)
 				
 				dragen_cnv_metrics_dict[sample] = parsed_cnv_metrics
+				
+			else:
+			
+				return dragen_cnv_metrics_dict
 		
 		return dragen_cnv_metrics_dict

--- a/pipelines/dragen_pipelines.py
+++ b/pipelines/dragen_pipelines.py
@@ -591,8 +591,11 @@ class DragenWGS:
 		
 			cnv_metrics_file = results_path.joinpath(sample).glob(f'*{sample}.cnv_metrics.csv')
 			
+			
 			if len(list(cnv_metrics_file)) == 1:
 			
+				cnv_metrics_file = results_path.joinpath(sample).glob(f'*{sample}.cnv_metrics.csv')
+				
 				cnv_file = list(cnv_metrics_file)[0]
 				
 				parsed_cnv_metrics = parsers.parse_dragen_cnv_metrics_file(cnv_file)

--- a/pipelines/dragen_pipelines.py
+++ b/pipelines/dragen_pipelines.py
@@ -577,3 +577,26 @@ class DragenWGS:
 				run_ploidy_metrics_dict[sample] = parsed_run_ploidy_metrics
 
 		return run_ploidy_metrics_dict
+		
+	def get_cnv_metrics(self):
+		"""
+		Get sample level CNV metrics from dragen cnv metrics file
+		"""
+		
+		results_path = Path(self.results_dir)
+		
+		dragen_cnv_metrics_dict = {}
+		
+		for sample in self.sample_names:
+		
+			cnv_metrics_file = results_path.joinpath(sample).glob(f'*{sample}.cnv_metrics.csv')
+			
+			if len(list(cnv_metrics_file)) == 1:
+			
+				cnv_file = list(cnv_metrics_file)[0]
+				
+				parsed_cnv_metrics = parsers.parse_dragen_cnv_metrics_file(cnv_file)
+				
+				dragen_cnv_metrics_dict[sample] = parsed_cnv_metrics
+		
+		return dragen_cnv_metrics_dict

--- a/pipelines/parsers.py
+++ b/pipelines/parsers.py
@@ -967,7 +967,35 @@ def parse_ploidy_metrics_file(ploidy_metrics_file):
 				dragen_ploidy_metrics_file_dict[new_key] = value
 				
 	return dragen_ploidy_metrics_file_dict
-
+	
+def parse_dragen_cnv_metrics_file(cnv_file):
+	"""
+	Parse the dragen sample level CNV metrics file
+	"""
+	
+	dragen_cnv_metrics_file_dict = {}
+	
+	with open(cnv_file) as file:
+	
+		dragen_cnv_file = csv.reader(file, delimiter=',')
+		
+		for row in dragen_cnv_file:
+		
+			prefix = row[0]
+			key = row[2]
+			value = row[3]
+			
+			#Reformat key to remove spaces and brackets and make lower case
+			
+			new_key = key.translate(str.maketrans('', '', string.punctuation.replace('_','')))
+			
+			new_key = new_key.lower().replace(' ', '_').replace('__','_')
+			
+			if prefix == 'CNV SUMMARY':
+			
+				dragen_cnv_metrics_file_dict[new_key] = value
+	
+	return dragen_cnv_metrics_file_dict
 
 def parse_custom_coverage_metrics(custom_coverage_file):
 	"""

--- a/qc_database/management/commands/update_database.py
+++ b/qc_database/management/commands/update_database.py
@@ -208,6 +208,20 @@ class Command(BaseCommand):
 								except:
 
 									raise Exception ("ERROR: Max CNVs called cutoff not in config file")
+									
+							if 'min_average_coverage' == key:
+							
+								try:
+									min_average_coverage_cutoff = config_dict['pipelines'][run_config_key]['min_average_coverage']
+
+									if created:
+
+										new_sample_analysis_obj.min_average_coverage_cutoff = min_average_coverage_cutoff
+
+								except:
+
+									raise Exception ("ERROR: Min Average Coverage cutoff not in config file")
+								
 
 					new_sample_analysis_obj.sex = sex
 					new_sample_analysis_obj.save()
@@ -389,6 +403,19 @@ class Command(BaseCommand):
 								except:
 
 									raise Exception("ERROR: max_cnv_calls_cutoff not in config file")
+									
+							if 'min_average_coverage' == key:
+							
+								try:
+									min_average_coverage_cutoff = config_dict['pipelines'][run_config_key]['min_average_coverage']
+
+									if created:
+
+										new_run_analysis_obj.min_average_coverage_cutoff = min_average_coverage_cutoff
+
+								except:
+
+									raise Exception ("ERROR: Min Average Coverage cutoff not in config file")
 
 					new_run_analysis_obj.save()
 

--- a/qc_database/management/commands/update_database.py
+++ b/qc_database/management/commands/update_database.py
@@ -862,6 +862,10 @@ class Command(BaseCommand):
 							logger.info (f'Putting ploidy metrics into db for run {run_analysis.run.run_id}')
 							dragen_ploidy_metrics_dict = dragen_wgs.get_ploidy_metrics()
 							management_utils.add_dragen_ploidy_metrics(dragen_ploidy_metrics_dict, run_analysis)
+							
+							logger.info(f'Putting CNV metrics into db for run {run_analysis.run.run_id}')
+							dragen_cnv_metrics_dict = dragen_wgs.get_cnv_metrics()
+							management_utils.add_dragen_cnv_metrics(dragen_cnv_metrics_dict, run_analysis)
 
 						else:
 
@@ -898,6 +902,11 @@ class Command(BaseCommand):
 							logger.info (f'Putting ploidy metrics into db for run {run_analysis.run.run_id}')
 							dragen_ploidy_metrics_dict = dragen_wgs.get_ploidy_metrics()
 							management_utils.add_dragen_ploidy_metrics(dragen_ploidy_metrics_dict, run_analysis)
+							
+							logger.info(f'Putting CNV metrics into db for run {run_analysis.run.run_id}')
+							dragen_cnv_metrics_dict = dragen_wgs.get_cnv_metrics()
+							management_utils.add_dragen_cnv_metrics(dragen_cnv_metrics_dict, run_analysis)
+
 
 					run_analysis.results_completed = run_complete
 					run_analysis.results_valid = run_valid

--- a/qc_database/management_utils.py
+++ b/qc_database/management_utils.py
@@ -675,8 +675,34 @@ def add_dragen_ploidy_metrics(dragen_ploidy_metrics, run_analysis_obj):
 
 			new_dragen_ploidy_metrics_obj = DragenPloidyMetrics(sample_analysis=sample_analysis_obj, ploidy_estimation=sample_data['ploidy_estimation'])
 			new_dragen_ploidy_metrics_obj.save()
+			
+def add_dragen_cnv_metrics(dragen_cnv_metrics_dict, run_analysis_obj):
+	"""
+	Add data from dragen sample CNV metrics file to database
+	"""
+	pipeline = run_analysis_obj.pipeline
+	run = run_analysis_obj.run
+	
+	for key in dragen_cnv_metrics_dict:
+	
+		sample_obj = Sample.objects.get(sample_id=key)
+		
+		sample_analysis_obj = SampleAnalysis.objects.get(sample=sample_obj,
+									run=run,
+									pipeline=pipeline,
+									analysis_type=run_analysis_obj.analysis_type)
 
-
+		existing_data = DragenCNVMetrics.objects.filter(sample_analysis=sample_analysis_obj)
+		
+		if len(existing_data) < 1:
+			
+			sample_data = dragen_cnv_metrics_dict[key]
+			
+			sample_data['sample_analysis'] = sample_analysis_obj
+			
+			new_dragen_cnv_metrics_obj = DragenCNVMetrics(**sample_data)
+			new_dragen_cnv_metrics_obj.save()
+				
 def add_fusion_contamination_metrics(contamination_metrics_dict, run_analysis_obj):
 	"""
 	Add data from fusion contamination file to database

--- a/qc_database/models.py
+++ b/qc_database/models.py
@@ -1711,6 +1711,24 @@ class CNVMetrics(models.Model):
 	exome_depth_count = models.IntegerField(null=True)
 	exome_depth_autosomal_reference_count = models.IntegerField(null=True)
 	exome_depth_x_reference_count = models.IntegerField(null=True)
+	
+class DragenCNVMetrics(models.Model):
+	"""
+	Model for sample level CNV calling metrics from DragenWGS
+	"""
+	sample_analysis = models.ForeignKey(SampleAnalysis, on_delete=models.CASCADE)
+	bases_in_reference_genome = models.IntegerField(null=True, blank=True)
+	average_alignment_coverage_over_genome = models.DecimalField(max_digits=6, decimal_places=2, null=True, blank=True)
+	number_of_filtered_records_total = models.IntegerField(null=True, blank=True)
+	number_of_filtered_records_duplicates = models.IntegerField(null=True, blank=True)
+	number_of_filtered_records_mapq = models.IntegerField(null=True, blank=True)
+	number_of_filtered_records_unmapped = models.IntegerField(null=True, blank=True)
+	number_of_target_intervals = models.IntegerField(null=True, blank=True)
+	number_of_segments = models.IntegerField(null=True, blank=True)
+	number_of_amplifications = models.IntegerField(null=True, blank=True)
+	number_of_deletions = models.IntegerField(null=True, blank=True)
+	number_of_passing_amplifications = models.IntegerField(null=True, blank=True)
+	number_of_passing_deletions = models.IntegerField(null=True, blank=True)
 
 
 auditlog.register(RunAnalysis)

--- a/qc_database/models.py
+++ b/qc_database/models.py
@@ -419,6 +419,7 @@ class RunAnalysis(models.Model):
 						# handles old runs where the check exists but CNV calling hasn't been run
 						pass
 						
+		#Coverage check for WGSCNV calls only
 		if 'min_average_coverage' in checks_to_do:
 		
 			for sample in new_samples_list:
@@ -1181,7 +1182,7 @@ class SampleAnalysis(models.Model):
 			
 	def passes_average_coverage(self):
 		"""
-		Checks if average coverage > cut off - CNV metric
+		Checks if average coverage > cut off - WGS CNV metric
 		"""
 		
 		dragen_cnv_metrics = DragenCNVMetrics.objects.get(sample_analysis=self)

--- a/qc_database/models.py
+++ b/qc_database/models.py
@@ -181,6 +181,7 @@ class RunAnalysis(models.Model):
 	min_on_target_reads=models.IntegerField(null=True, blank=True)
 	max_cnv_calls=models.IntegerField(null=True, blank=True)
 	display_cnv_qc_metrics=models.BooleanField(default=False)
+	min_average_coverage_cutoff=models.IntegerField(null=True, blank=True)
 
 	#for TSO500 only- ntc contamination for other runs in sampleAnalysis object
 	max_ntc_contamination = models.IntegerField(null=True, blank=True)
@@ -407,15 +408,24 @@ class RunAnalysis(models.Model):
 
 			for sample in new_samples_list:
 				
-				try:
-					if sample.passes_cnv_calling() != True:
+				#Only hard failure for GE, just a warning in WGS
+				if 'DragenGE' in self.pipeline.pipeline_id:
+					try:
+						if sample.passes_cnv_calling() != True:
 
-						reasons_to_fail.append('CNV Calling Fail')
+							reasons_to_fail.append('CNV Calling Fail')
 				
-				except ObjectDoesNotExist:
-					# handles old runs where the check exists but CNV calling hasn't been run
-					pass
-					
+					except ObjectDoesNotExist:
+						# handles old runs where the check exists but CNV calling hasn't been run
+						pass
+						
+		if 'min_average_coverage' in checks_to_do:
+		
+			for sample in new_samples_list:
+			
+				if sample.passes_average_coverage() != True:
+				
+					reasons_to_fail.append('Average Coverage Fail')
 
 		# DNA
 		if 'ntc_contamination_TSO500' in checks_to_do:
@@ -539,6 +549,7 @@ class SampleAnalysis(models.Model):
 	contamination_cutoff = models.DecimalField(max_digits=6, decimal_places=3, default=0.15, null=True, blank=True)
 	ntc_contamination_cutoff = models.DecimalField(max_digits=6, decimal_places=3, default=10.0, null=True, blank=True)
 	max_cnvs_called_cutoff = models.IntegerField(null=True, blank=True)
+	min_average_coverage_cutoff = models.IntegerField(null=True, blank=True)
 
 	history = AuditlogHistoryField()
 
@@ -1151,7 +1162,68 @@ class SampleAnalysis(models.Model):
 				return True
 			else:
 				return False
+				
+	def get_average_coverage(self):
+		"""
+		Average coverage metric for CNV calling
+		"""
+		
+		#Only do this for WGS
+		if 'DragenWGS' in self.pipeline.pipeline_id:
+			
+			dragen_cnv_metrics = DragenCNVMetrics.objects.get(sample_analysis=self)
+			
+			return dragen_cnv_metrics.average_alignment_coverage_over_genome
+			
+		else:
+		
+			return "NA"
+			
+	def passes_average_coverage(self):
+		"""
+		Checks if average coverage > cut off - CNV metric
+		"""
+		
+		dragen_cnv_metrics = DragenCNVMetrics.objects.get(sample_analysis=self)
+		
+		if dragen_cnv_metrics.average_alignment_coverage_over_genome > self.min_average_coverage_cutoff:
+		
+			return True
+		
+		else:
+		
+			return False
+			
+	def get_cnv_count(self):
+		"""
+		Combination of passing amplifications and passing deletions
+		"""
+		
+		#Only do this for WGS:
+		if 'DragenWGS' in self.pipeline.pipeline_id:
+		
+			dragen_cnv_metrics = DragenCNVMetrics.objects.get(sample_analysis=self)
+			
+			total = dragen_cnv_metrics.number_of_passing_amplifications + dragen_cnv_metrics.number_of_passing_deletions
+			
+			return total
+			
+		else:
+		
+			return "NA"
+			
+	def passes_cnv_count(self):
+		"""
+		if total number of passing amplifcation and passing deletions is greater than cut off
+		"""
 
+		if int(self.get_cnv_count()) < int(self.max_cnvs_called_cutoff):
+		
+			return True
+			
+		else:
+		
+			return False
 
 class SampleFastqcData(models.Model):
 	"""
@@ -1719,6 +1791,7 @@ class DragenCNVMetrics(models.Model):
 	sample_analysis = models.ForeignKey(SampleAnalysis, on_delete=models.CASCADE)
 	bases_in_reference_genome = models.IntegerField(null=True, blank=True)
 	average_alignment_coverage_over_genome = models.DecimalField(max_digits=6, decimal_places=2, null=True, blank=True)
+	number_of_alignment_records = models.IntegerField(null=True, blank=True)
 	number_of_filtered_records_total = models.IntegerField(null=True, blank=True)
 	number_of_filtered_records_duplicates = models.IntegerField(null=True, blank=True)
 	number_of_filtered_records_mapq = models.IntegerField(null=True, blank=True)

--- a/qc_database/templates/auto_qc/view_run_analysis.html
+++ b/qc_database/templates/auto_qc/view_run_analysis.html
@@ -84,6 +84,18 @@
 	</tr>
 
 	{% endif %}
+	
+	{% if 'min_average_coverage' in checks_to_do %}
+	
+	<tr>
+		<td> Minimum Average Coverage for CNVs</td>
+		<td> {{run_analysis.min_average_coverage_cutoff}}</td>
+	</tr>
+	<tr>
+		<td> Maximum CNV Count (Warning Only)</td>
+		<td> {{run_analysis.max_cnv_calls}}</td>
+	</tr>
+	{% endif %}
 
 	{% if 'sensitivity' in checks_to_do %}
 
@@ -456,6 +468,14 @@
 	  <th> Passes CNV calling</th>
 
 	  {% endif %}
+	  
+	  {% if 'min_average_coverage' in checks_to_do %}
+	  
+	  <th> Average Coverage </th>
+	  
+	  <th> CNV Count </th>
+	  
+	  {% endif %}
 
 
 	  {% if 'sex_match' in checks_to_do %}
@@ -514,6 +534,12 @@
 			{% if 'ntc_contamination' in checks_to_do %}
 			<td class="table-dark"> {{sample_analysis.passes_ntc_contamination}} </td>
 			{% endif %}
+			
+			{% if 'min_average_coverage' in checks_to_do %}
+			<td class="table-dark">NA</td>
+			<td class="table-dark">NA</td>
+			
+			{% endif %}
 
 			{% if 'sex_match' in checks_to_do %}
 			<td class="table-dark"> {{sample_analysis.get_sex}} </td>
@@ -538,7 +564,8 @@
 			{% if run_analysis.display_cnv_qc_metrics %}
 			<td class="table-dark">{{sample_analysis.passes_cnv_calling}}</td>
 			{% endif %}
-
+			
+			
 		{% else %}
 
 
@@ -701,6 +728,22 @@
 					<td class="table-danger">{{ sample_analysis.passes_cnv_calling }}</td>
 				{% endif %}
 			{% endif %}
+		{% endif %}
+		
+		{% if 'min_average_coverage' in checks_to_do %}
+		
+			{% if sample_analysis.passes_average_coverage %}
+			<td class="table-success">{{ sample_analysis.get_average_coverage }}</td>
+			{% else %}
+			<td class="table-danger">{{ sample_analysis.get_average_coverage }}</td>
+			{% endif %}
+			
+			{% if sample_analysis.passes_cnv_count %}
+			<td class="table-success">{{ sample_analysis.get_cnv_count }}</td>
+			{% else %}
+			<td class="table-warn">{{ sample_analysis.get_cnv_count }}</td>
+			{% endif %}
+			
 		{% endif %}
 
 		{% if 'sex_match' in checks_to_do %}

--- a/qc_database/templates/auto_qc/view_run_analysis.html
+++ b/qc_database/templates/auto_qc/view_run_analysis.html
@@ -741,7 +741,7 @@
 			{% if sample_analysis.passes_cnv_count %}
 			<td class="table-success">{{ sample_analysis.get_cnv_count }}</td>
 			{% else %}
-			<td class="table-warn">{{ sample_analysis.get_cnv_count }}</td>
+			<td class="table-warning">{{ sample_analysis.get_cnv_count }}</td>
 			{% endif %}
 			
 		{% endif %}

--- a/qc_database/tests/test_cnv_qc.py
+++ b/qc_database/tests/test_cnv_qc.py
@@ -1,8 +1,8 @@
 from django.test import TestCase
 import unittest
 
-from qc_database.models import AnalysisType, CNVMetrics, Pipeline, Run, RunAnalysis, Sample, SampleAnalysis, WorkSheet
-from pipelines.parsers import parse_exome_postprocessing_cnv_qc_metrics
+from qc_database.models import AnalysisType, CNVMetrics, Pipeline, Run, RunAnalysis, Sample, SampleAnalysis, WorkSheet, DragenCNVMetrics
+from pipelines.parsers import parse_exome_postprocessing_cnv_qc_metrics, parse_dragen_cnv_metrics_file
 
 class TestParseCNVQC(unittest.TestCase):
     
@@ -150,6 +150,160 @@ class TestCNVModels(TestCase):
         CNVMetrics.objects.filter(sample_analysis=self.sample_analysis_obj).update(exome_depth_x_reference_count=1)
         passes_cnv_calling = self.sample_analysis_obj.passes_cnv_calling()
         self.assertFalse(passes_cnv_calling)
+
+class TestWGSCNVQC(unittest.TestCase):
+    
+    def setUp(self):
+
+        self.test_data_1 = "qc_database/tests/test_data/wgs_test1.cnv_metrics.csv"
+        self.test_data_2 = "qc_database/tests/test_data/wgs_test2.cnv_metrics.csv"
+
+    def test_parse_wgs_cnv_qc_metrics(self):
+        """
+        Test that WGS CNV metrics files are being parsed correctly
+        """
+        expected_1 = {
+            "bases_in_reference_genome":"3215250450",
+            "average_alignment_coverage_over_genome":"26.65",
+            "number_of_alignment_records":"620819033",
+            "number_of_filtered_records_total":"3423906",
+            "number_of_filtered_records_duplicates":"0",
+            "number_of_filtered_records_mapq":"1358349",
+            "number_of_filtered_records_unmapped":"2065557",
+            "number_of_target_intervals":"2430731",
+            "number_of_segments":"1564",
+            "number_of_amplifications":"149",
+            "number_of_deletions":"358",
+            "number_of_passing_amplifications":"87",
+            "number_of_passing_deletions":"62"
+        }
+        result_1 = parse_dragen_cnv_metrics_file(self.test_data_1)
+        self.assertEqual(expected_1, result_1)
+        
+        expected_2 = {
+            "bases_in_reference_genome":"3215250450",
+            "average_alignment_coverage_over_genome":"47.54",
+            "number_of_alignment_records":"1096341764",
+            "number_of_filtered_records_total":"6518876",
+            "number_of_filtered_records_duplicates":"0",
+            "number_of_filtered_records_mapq":"2246715",
+            "number_of_filtered_records_unmapped":"4272161",
+            "number_of_target_intervals":"2430731",
+            "number_of_segments":"1700",
+            "number_of_amplifications":"140",
+            "number_of_deletions":"530",
+            "number_of_passing_amplifications":"79",
+            "number_of_passing_deletions":"62"
+        }
+        result_2 = parse_dragen_cnv_metrics_file(self.test_data_2)
+        self.assertEqual(expected_2, result_2)
+
+class test_WGS_cnv_checks(unittest.TestCase):  
+
+    def setUp(self):
+ 
+        Run.objects.create(
+            run_id = "TEST_RUN"
+        )
+        self.run_obj = Run.objects.get(run_id="TEST_RUN")
+
+        Sample.objects.create(
+            sample_id = "sample_1"
+        )
+        self.sample1_obj = Sample.objects.get(sample_id="sample_1")
+        
+        Sample.objects.create(
+            sample_id = "sample_2"
+        )
+        self.sample2_obj = Sample.objects.get(sample_id="sample_2")
+
+        Pipeline.objects.create(
+            pipeline_id = "DragenWGS-master"
+        )
+        self.pipeline_obj = Pipeline.objects.get(pipeline_id="DragenWGS-master")
+
+        AnalysisType.objects.create(
+            analysis_type_id = "WGS"
+        )
+        self.analysis_type_obj = AnalysisType.objects.get(analysis_type_id="WGS")
+
+        WorkSheet.objects.create(
+            worksheet_id = "TEST_WORKSHEET"
+        )
+        self.worksheet_obj = WorkSheet.objects.get(worksheet_id="TEST_WORKSHEET")
+
+        RunAnalysis.objects.create(
+            run=self.run_obj,
+            pipeline=self.pipeline_obj,
+            analysis_type=self.analysis_type_obj,
+            max_cnv_calls=300,
+            min_average_coverage_cutoff=30
+        )
+
+        SampleAnalysis.objects.create(
+            sample=self.sample1_obj,
+            run=self.run_obj,
+            pipeline=self.pipeline_obj,
+            analysis_type=self.analysis_type_obj,
+            worksheet=self.worksheet_obj,
+            results_completed=True,
+            results_valid=True,
+            sex="male",
+            contamination_cutoff=10,
+            ntc_contamination_cutoff=10,
+            max_cnvs_called_cutoff=300,
+            min_average_coverage_cutoff=30
+        )
+        self.sample_analysis_obj_1 = SampleAnalysis.objects.get(sample=self.sample1_obj)
+        
+        SampleAnalysis.objects.create(
+            sample=self.sample2_obj,
+            run=self.run_obj,
+            pipeline=self.pipeline_obj,
+            analysis_type=self.analysis_type_obj,
+            worksheet=self.worksheet_obj,
+            results_completed=True,
+            results_valid=True,
+            sex="male",
+            contamination_cutoff=10,
+            ntc_contamination_cutoff=10,
+            max_cnvs_called_cutoff=300,
+            min_average_coverage_cutoff=30
+        )
+        self.sample_analysis_obj_2 = SampleAnalysis.objects.get(sample=self.sample2_obj)  
+        
+        DragenCNVMetrics.objects.create(
+            sample_analysis = self.sample_analysis_obj_1,
+            average_alignment_coverage_over_genome = 26.65,
+            number_of_passing_amplifications = 87,
+            number_of_passing_deletions = 62
+        )
+        self.dragen_cnv_metrics_1 = DragenCNVMetrics.objects.get(sample_analysis=self.sample_analysis_obj_1)
+        
+        DragenCNVMetrics.objects.create(
+            sample_analysis = self.sample_analysis_obj_2,
+            average_alignment_coverage_over_genome = 47.54,
+            number_of_passing_amplifications = 200,
+            number_of_passing_deletions = 200
+        )
+        self.dragen_cnv_metrics_2 = DragenCNVMetrics.objects.get(sample_analysis=self.sample_analysis_obj_2)
+    
+    def test_cnv_checks(self):
+        """
+        Test that CNV metrics populate models correctly and tests pass/fail as expected
+        """
+        passes_cnv_coverage_1 = self.sample_analysis_obj_1.passes_average_coverage()
+        self.assertFalse(passes_cnv_coverage_1)
+
+        passes_cnv_coverage_2 = self.sample_analysis_obj_2.passes_average_coverage()
+        self.assertTrue(passes_cnv_coverage_2)
+        
+        passes_cnv_count_1 = self.sample_analysis_obj_1.passes_cnv_count()
+        self.assertTrue(passes_cnv_count_1)
+        
+        passes_cnv_count_2 = self.sample_analysis_obj_2.passes_cnv_count()
+        self.assertFalse(passes_cnv_count_2)
+        
 
 if __name__ == "__main__":
     unittest.main()

--- a/qc_database/tests/test_data/wgs_test1.cnv_metrics.csv
+++ b/qc_database/tests/test_data/wgs_test1.cnv_metrics.csv
@@ -1,0 +1,14 @@
+SEX GENOTYPER,,19M19911,XX,0.9896
+CNV SUMMARY,,Bases in reference genome,3215250450
+CNV SUMMARY,,Average alignment coverage over genome,26.65
+CNV SUMMARY,,Number of alignment records,620819033
+CNV SUMMARY,,Number of filtered records (total),3423906,0.55
+CNV SUMMARY,,Number of filtered records (duplicates),0,0.00
+CNV SUMMARY,,Number of filtered records (MAPQ),1358349,0.22
+CNV SUMMARY,,Number of filtered records (unmapped),2065557,0.33
+CNV SUMMARY,,Number of target intervals,2430731
+CNV SUMMARY,,Number of segments,1564
+CNV SUMMARY,,Number of amplifications,149
+CNV SUMMARY,,Number of deletions,358
+CNV SUMMARY,,Number of passing amplifications,87,58.39
+CNV SUMMARY,,Number of passing deletions,62,17.32

--- a/qc_database/tests/test_data/wgs_test2.cnv_metrics.csv
+++ b/qc_database/tests/test_data/wgs_test2.cnv_metrics.csv
@@ -1,0 +1,14 @@
+SEX GENOTYPER,,21M07410,XX,0.9884
+CNV SUMMARY,,Bases in reference genome,3215250450
+CNV SUMMARY,,Average alignment coverage over genome,47.54
+CNV SUMMARY,,Number of alignment records,1096341764
+CNV SUMMARY,,Number of filtered records (total),6518876,0.59
+CNV SUMMARY,,Number of filtered records (duplicates),0,0.00
+CNV SUMMARY,,Number of filtered records (MAPQ),2246715,0.20
+CNV SUMMARY,,Number of filtered records (unmapped),4272161,0.39
+CNV SUMMARY,,Number of target intervals,2430731
+CNV SUMMARY,,Number of segments,1700
+CNV SUMMARY,,Number of amplifications,140
+CNV SUMMARY,,Number of deletions,530
+CNV SUMMARY,,Number of passing amplifications,79,56.43
+CNV SUMMARY,,Number of passing deletions,62,11.70


### PR DESCRIPTION
Addition of CNV cut offs for WGS data. 
- Average depth > 30X (pass/fail) and total CNV count < 300 (warning only) (See accompanying validation summary). 
- Will display for all runs going forward, but we won't pass/fail on this metric until SOP changes are implemented.
- Unit tests added and all run successfully. 
