### PR TITLE
Samplesheet generator bug fix

### DIFF
--- a/sample_sheet/templates/sample_sheet/worksheet_base.html
+++ b/sample_sheet/templates/sample_sheet/worksheet_base.html
@@ -39,7 +39,7 @@
             <div class="row justify-content-center">
                 <div class="col-5">
                     {% if worksheet_checks.clin_sci.overall == 'complete' and worksheet_checks.tech_team.overall == 'complete' %}
-                    <button data-bs-toggle="modal" data-bs-target="#3AAFA9" class="btn btn-success" style="background-color: white !important;">
+                    <button data-bs-toggle="modal" data-bs-target="#download-samplesheet" class="btn btn-success">
                       <span class="fa fa-file-download" style="width: 30px; color: white;"></span>
                       Download samplesheet
                     </button>


### PR DESCRIPTION
Download samplesheet button stopped working after the colour changes to the samplesheet generator, it was due to the modal reference in the HTML being updates to a colur reference instead, so the modal never appeared when the button is clicked