### PR TITLE
Changing dragenwgs run complete and valid markers

### DIFF
--- a/config/config_gen01.yaml
+++ b/config/config_gen01.yaml
@@ -64,12 +64,7 @@ pipelines:
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']
     sample_not_expected_files: []
-    run_expected_files: ['*.hard-filtered.vcf.gz',
-                  '*.vc_metrics.csv',
-                 'post_processing/results/relatedness/*.relatedness2',
-                 'post_processing/results/annotated_vcf/*.vcf.gz',
-                 'post_processing/results/database_config/*_config.csv',
-               ]
+    run_expected_files: ['post_processing/results/post_processing_finished.txt']
     run_not_expected_files: []
     post_sample_files: []
 
@@ -95,12 +90,7 @@ pipelines:
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']
     sample_not_expected_files: []
-    run_expected_files: ['*.hard-filtered.vcf.gz',
-                  '*.vc_metrics.csv',
-                 'post_processing/results/relatedness/*.relatedness2',
-                 'post_processing/results/annotated_vcf/*.vcf.gz',
-                 'post_processing/results/database_config/*_config.csv',
-               ]
+    run_expected_files: ['post_processing/results/post_processing_finished.txt']
     run_not_expected_files: []
     post_sample_files: []
 
@@ -126,12 +116,7 @@ pipelines:
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']
     sample_not_expected_files: []
-    run_expected_files: ['*.hard-filtered.vcf.gz',
-                  '*.vc_metrics.csv',
-                 'post_processing/results/relatedness/*.relatedness2',
-                 'post_processing/results/annotated_vcf/*.vcf.gz',
-                 'post_processing/results/database_config/*_config.csv',
-               ]
+    run_expected_files: ['post_processing/results/post_processing_finished.txt']
     run_not_expected_files: []
     post_sample_files: []
 
@@ -157,12 +142,7 @@ pipelines:
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']
     sample_not_expected_files: []
-    run_expected_files: ['*.hard-filtered.vcf.gz',
-                  '*.vc_metrics.csv',
-                 'post_processing/results/relatedness/*.relatedness2',
-                 'post_processing/results/annotated_vcf/*.vcf.gz',
-                 'post_processing/results/database_config/*_config.csv',
-               ]
+    run_expected_files: ['post_processing/results/post_processing_finished.txt']
     run_not_expected_files: []
     post_sample_files: []
 

--- a/config/config_local.yaml
+++ b/config/config_local.yaml
@@ -22,12 +22,7 @@ pipelines:
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']
     sample_not_expected_files: []
-    run_expected_files: ['*.hard-filtered.vcf.gz',
-                  '*.vc_metrics.csv',
-                 'post_processing/results/relatedness/*.relatedness2',
-                 'post_processing/results/annotated_vcf/*.vcf.gz',
-                 'post_processing/results/database_config/*_config.csv',
-               ]
+    run_expected_files: ['post_processing/results/post_processing_finished.txt']
     run_not_expected_files: []
     post_sample_files: []
 
@@ -52,11 +47,7 @@ pipelines:
                   '*.mapping_metrics.csv',
                   '*.insert-stats.tab']
     sample_not_expected_files: []
-    run_expected_files: ['*.hard-filtered.vcf.gz',
-                  '*.vc_metrics.csv',
-                 'post_processing/results/relatedness/*.relatedness2',
-                 'post_processing/results/annotated_vcf/*.vcf.gz',
-                 'post_processing/results/database_config/*_config.csv',
+    run_expected_files: ['post_processing/results/post_processing_finished.txt']
                ]
     run_not_expected_files: []
     post_sample_files: []

--- a/pipelines/dragen_pipelines.py
+++ b/pipelines/dragen_pipelines.py
@@ -265,7 +265,7 @@ class DragenWGS:
 				sample_not_expected_files =[],
 				run_not_expected_files= [],
 				post_sample_files = [],
-				run_complete_marker  = 'post_processing_finished.txt',
+				run_complete_marker  = 'post_processing/results/post_processing_finished.txt',
 				sample_complete_marker  = 'post_processing_finished.txt'
 				):
 
@@ -369,26 +369,9 @@ class DragenWGS:
 
 		results_path = Path(self.results_dir)
 
-		new_path = False
+		marker = results_path.glob(self.run_complete_marker)
 		
-		for i in self.run_expected_files:
-
-			if 'post_processing' in i:
-
-				new_path = True
-				break
-
-		if new_path:
-
-			results_path = results_path.joinpath('post_processing/results/')
-
-		else:
-
-			results_path = results_path.joinpath('results')
-
-		marker = results_path.glob(self.sample_complete_marker)
-
-		if len(list(marker)) >= 1:
+		if len(list(marker)) == 1:
 
 			return True
 
@@ -397,34 +380,30 @@ class DragenWGS:
 
 	def run_is_valid(self):
 		"""
-		Look for files which have to be present for a run level pipeline to have completed \
-		correctly.
-
-		Look for files which if present indicate the pipeline has not finished correctly e.g. intermediate files.
+		Read the file nextflow creates at the end of the run (post_processing/results/post_processing_finished.txt and check if it says fail or success. 
 		"""
 
-		results_path = Path(self.results_dir)
-
-		# check files we want to be there are there
-		for file in self.run_expected_files:
+		if self.run_is_complete():
+		
+			results_path = Path(self.results_dir)
 			
-			found_file = results_path.glob(file)
-
-			if len(list(found_file)) != 1:
-								
-				return False
-
-		# check file we do not want to be there are not there
-		for file in self.run_not_expected_files:
+			marker = results_path.glob(self.run_complete_marker)
 			
-
-			found_file = results_path.glob(file)
-
-			if len(list(found_file)) > 0:
-
-				return False
+			marker = list(marker)[0]
 			
-		return True
+			#last line in file
+			last_report = ''
+			
+			with open(marker, 'r') as outfile:
+			
+				for x in outfile:
+					last_report = x.strip()
+					
+			if 'success' in last_report:
+			
+				return True
+				
+		return False
 
 	def run_and_samples_complete(self):
 			"""


### PR DESCRIPTION
Change to fix https://github.com/AWGL/auto_qc/issues/118 where runs were showing as complete whilst still running. Changed marker to be the post_processing_finished.txt file, matching the process being undertaken in DragenGE. 

Unit tests run end to end apart from WGS CNV test which has a fix in https://github.com/AWGL/auto_qc/pull/145

Test data on hard drive in AutoQC_Test2/. Tested on both WGS and FastWGS. 