### PR TITLE
Bug fix for WGS CNV metrics if no file present e.g. NTC

### DIFF
--- a/pipelines/dragen_pipelines.py
+++ b/pipelines/dragen_pipelines.py
@@ -583,6 +583,7 @@ class DragenWGS:
 				
 			else:
 			
-				return dragen_cnv_metrics_dict
+				#if not CNV metrics file (i.e. NTC) add empty dictionary for sample
+				dragen_cnv_metrics_dict[sample] = {}
 		
 		return dragen_cnv_metrics_dict


### PR DESCRIPTION
Bug fix for https://github.com/AWGL/auto_qc/issues/155 where CNV count was showing as NA for WGS sample despite all the files being present. Issue was because the creation of the cnv metrics models was in a for loop, and if no file was present for that sample, it returned the dictionary. Therefore if the NTC wasn't the last sample processed, the dictionary was returned early and partially completed. 

Small code change to fix the bug. 
Unit tests functional. 