### PR TITLE
Issue162

### DIFF
--- a/config/config_local.yaml
+++ b/config/config_local.yaml
@@ -51,7 +51,6 @@ pipelines:
     run_not_expected_files: []
     post_sample_files: []
 
-
   germline_enrichment_nextflow-master-AgilentOGTFH:
     results_dir:  '/media/joseph/Storage/data/results/'
     qc_checks: [pct_q30, fastqc, ntc_contamination, variant_check, coverage]
@@ -96,7 +95,7 @@ pipelines:
     sample_expected_files: ['*_VariantReport.txt',
                   '*.bam',
                   '*_DepthOfCoverage.sample_summary',
-                  '*_qc.txt',
+                  '*_QC.txt',
                   '*_filtered_meta_annotated.vcf'
                   ]
     sample_not_expected_files: ['*_fastqc.zip']
@@ -115,7 +114,7 @@ pipelines:
     sample_expected_files: ['*_VariantReport.txt',
                   '*.bam',
                   '*_DepthOfCoverage.sample_summary',
-                  '*_qc.txt',
+                  '*_QC.txt',
                   '*_filtered_meta_annotated.vcf',
                   'hotspot_variants'
                   ]
@@ -135,7 +134,6 @@ pipelines:
     run_expected_files: []
     metrics_file: ['*_ntc_cont.txt','*_fastqc_status.txt','_read_number.txt']
 
-
   TSO500-master-TSO500_RNA:
     results_dir:  '/home/sophieshaw/AutoQC_somatic_enrichment_nextflow/'
     min_q30_score: 0.8
@@ -146,7 +144,6 @@ pipelines:
     run_completed_files: ['run_complete.txt']
     run_expected_files: ['RNA_QC_combined.txt', 'contamination-*.csv' ,'completed_samples.txt']
     metrics_file: ['RNA_QC_combined.txt']
-
 
   DragenGE-master-IlluminaTruSightOne:
     results_dir:  '/media/joseph/Storage/data/dragen_results/'

--- a/qc_database/models.py
+++ b/qc_database/models.py
@@ -642,13 +642,20 @@ class SampleAnalysis(models.Model):
 			if len(fastqc_objs) == 0:
 
 				return None
-				
-		#If check for either R1 or R2 is a fail, set metric as fail
+
+		#Empty variables for metric checks
+		basic = ""
+		per_base = ""
+		per_tile = ""
+		per_seq = ""
+		n_content = ""
+		
+		#If metric is already a fail or new metric is a fail, make it a fail, otherwise change metric to last fastqc check
 		for fastqc in fastqc_objs:
 			try:
 				new_basic = fastqc.basic_statistics
 				
-				if new_basic == "FAIL":
+				if new_basic == "FAIL" or basic == "FAIL":
 				
 					basic = "FAIL"
 					
@@ -662,7 +669,7 @@ class SampleAnalysis(models.Model):
 			try:
 				new_per_base = fastqc.per_base_sequencing_quality
 				
-				if new_per_base == "FAIL":
+				if new_per_base == "FAIL" or per_base == "FAIL":
 				
 					per_base = "FAIL"
 					
@@ -676,7 +683,7 @@ class SampleAnalysis(models.Model):
 			try:
 				new_per_tile = fastqc.per_tile_sequence_quality
 				
-				if new_per_tile == "FAIL":
+				if new_per_tile == "FAIL" or per_tile == "FAIL":
 				
 					per_tile = "FAIL"
 					
@@ -690,7 +697,7 @@ class SampleAnalysis(models.Model):
 			try:
 				new_per_seq = fastqc.per_sequence_quality_scores
 				
-				if new_per_seq == "FAIL":
+				if new_per_seq == "FAIL" or per_seq == "FAIL":
 				
 					per_seq = "FAIL"
 					
@@ -704,7 +711,7 @@ class SampleAnalysis(models.Model):
 				
 			new_n_content = fastqc.per_base_n_content
 			
-			if new_n_content == "FAIL":
+			if new_n_content == "FAIL" or n_content == "FAIL":
 			
 				n_content = "FAIL"
 				

--- a/qc_database/models.py
+++ b/qc_database/models.py
@@ -632,8 +632,6 @@ class SampleAnalysis(models.Model):
 		"""
 		Give Exact Metrics for FastQC
 		"""
-		#Empty list for metrics
-		Metrics=[]
 		
 		fastqc_objs = SampleFastqcData.objects.filter(sample_analysis=self)
 		
@@ -644,25 +642,77 @@ class SampleAnalysis(models.Model):
 			if len(fastqc_objs) == 0:
 
 				return None
-
+				
+		#If check for either R1 or R2 is a fail, set metric as fail
 		for fastqc in fastqc_objs:
 			try:
-				Metrics.append(fastqc.basic_statistics)
+				new_basic = fastqc.basic_statistics
+				
+				if new_basic == "FAIL":
+				
+					basic = "FAIL"
+					
+				else:
+				
+					basic = new_basic
+				
 			except AttributeError: # dragen fastqc doesn't check this
-				Metrics.append("N/A")
+				basic = "N/A"
+			
 			try:
-				Metrics.append(fastqc.per_base_sequencing_quality)
+				new_per_base = fastqc.per_base_sequencing_quality
+				
+				if new_per_base == "FAIL":
+				
+					per_base = "FAIL"
+					
+				else:
+				
+					per_base = new_per_base				
+				
 			except AttributeError: # difference in attribute name between the two models
-				Metrics.append(fastqc.per_base_sequence_quality)
+				per_base = fastqc.per_base_sequence_quality
+
 			try:
-				Metrics.append(fastqc.per_tile_sequence_quality)
+				new_per_tile = fastqc.per_tile_sequence_quality
+				
+				if new_per_tile == "FAIL":
+				
+					per_tile = "FAIL"
+					
+				else:
+				
+					per_tile = new_per_tile
+					
 			except AttributeError: # dragen fastqc doesn't check this
-				Metrics.append("N/A")
+				per_tile = "N/A"
+
 			try:
-				Metrics.append(fastqc.per_sequence_quality_scores)
+				new_per_seq = fastqc.per_sequence_quality_scores
+				
+				if new_per_seq == "FAIL":
+				
+					per_seq = "FAIL"
+					
+				else:
+				
+					per_seq = new_per_seq
+					
 			except AttributeError: # difference in attribute name between the two models
-				Metrics.append(fastqc.per_sequence_quality_score)
-			Metrics.append(fastqc.per_base_n_content)
+				per_seq = fastqc.per_sequence_quality_score
+				
+				
+			new_n_content = fastqc.per_base_n_content
+			
+			if new_n_content == "FAIL":
+			
+				n_content = "FAIL"
+				
+			else:
+			
+				n_content = new_n_content
+			
+			Metrics = (basic,per_base,per_tile,per_seq,n_content)
 		
 		return Metrics
 	

--- a/qc_database/tests/tests.py
+++ b/qc_database/tests/tests.py
@@ -53,7 +53,6 @@ class TestAutoQC(TestCase):
 		self.assertEqual(run_analysis.passes_auto_qc(), (False, ['FASTQC Fail'],['19M07162']))
 	
 
-	
 	def test_contamination_fail(self):
 
 		run_analysis= RunAnalysis.objects.get(pk=16)
@@ -113,6 +112,7 @@ class TestAutoQC(TestCase):
 
 		self.assertEqual(run_analysis.passes_auto_qc(), (False, ['Sex Match Fail'],['19M07162']))
 
+
 	def test_variant_count_fail(self):
 
 		run_analysis= RunAnalysis.objects.get(pk=16)
@@ -131,3 +131,27 @@ class TestAutoQC(TestCase):
 		sex.save()
 
 		self.assertEqual(run_analysis.passes_auto_qc(), (False, ['Sex Match Fail'],['19M07162']))
+
+
+	def test_determine_worst_consequence(self):
+		
+		list1 = ["PASS", "WARN", "FAIL"]
+		list2 = ["PASS", "WARN", "PASS"]
+		list3 = ["PASS", "PASS", "PASS"]
+		list4 = []
+		list5 = ["PASS", "PASS", "PASS "]
+		list6 = ["PASS", "FAIL", "FIAL"]
+
+		list1_worst_consequence = SampleAnalysis.determine_worst_consequence(list1)
+		list2_worst_consequence = SampleAnalysis.determine_worst_consequence(list2)
+		list3_worst_consequence = SampleAnalysis.determine_worst_consequence(list3)
+		list4_worst_consequence = SampleAnalysis.determine_worst_consequence(list4)
+		list5_worst_consequence = SampleAnalysis.determine_worst_consequence(list5)
+
+		self.assertEqual(list1_worst_consequence, "FAIL")
+		self.assertEqual(list2_worst_consequence, "WARN")
+		self.assertEqual(list3_worst_consequence, "PASS")
+		self.assertEqual(list4_worst_consequence, "N/A")
+		self.assertEqual(list5_worst_consequence, "PASS")
+		with self.assertRaises(KeyError):
+			SampleAnalysis.determine_worst_consequence(list6)


### PR DESCRIPTION
Fix which closes #162.

FastQC hover box was not correctly displaying the metrics and instead only showing R1. Now make sure that it displays fail if either R1 or R2 is a fail for any of the metrics. Also allows for checks across multiple lanes etc. 

Tested for CRM with data on new hard drive under Sophie/ and for TSO500 and ctDNA with data on sticker hardrive under AutoQC_SVD_Test.

Unit tests all pass.

