### PR TITLE
Min/max NonacusFH variant thresholds updated to <30, >90 respectively.

### DIFF
--- a/config/config_gen01.yaml
+++ b/config/config_gen01.yaml
@@ -168,8 +168,8 @@ pipelines:
     contamination_cutoff: 0.025
     ntc_contamination_cutoff: 10
     min_fastq_size: 0
-    min_variants: 20
-    max_variants: 80
+    min_variants: 30
+    max_variants: 90
     min_coverage: 0.95
 
   deepvariant_nextflow-development-NonacusFH:
@@ -179,8 +179,8 @@ pipelines:
     contamination_cutoff: 0.025
     ntc_contamination_cutoff: 10
     min_fastq_size: 0
-    min_variants: 20
-    max_variants: 80
+    min_variants: 30
+    max_variants: 90
     min_coverage: 0.95
 
   deepvariant_nextflow-main-AgilentOGTFH:

--- a/config/config_local.yaml
+++ b/config/config_local.yaml
@@ -69,8 +69,8 @@ pipelines:
     contamination_cutoff: 0.025
     ntc_contamination_cutoff: 10
     min_fastq_size: 0
-    min_variants: 20
-    max_variants: 80
+    min_variants: 30
+    max_variants: 90
     min_coverage: 0.95
 
   deepvariant_nextflow-development-NonacusFH:
@@ -80,8 +80,8 @@ pipelines:
     contamination_cutoff: 0.025
     ntc_contamination_cutoff: 10
     min_fastq_size: 0
-    min_variants: 20
-    max_variants: 80
+    min_variants: 30
+    max_variants: 90
     min_coverage: 0.95
 
   deepvariant_nextflow-main-AgilentOGTFH:


### PR DESCRIPTION
Min/max thresholds for number of variants identified by NonacusFH pipeline updated as per issue #196. Both gen01 and local configs updated.