### PR TITLE
Development - Hotfix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,10 +4,14 @@ It contains all changes from 2024-07-09 onwards
 
 ## [Unreleased]
 
-## [v2.0.1] - 11/07/2024
+## [v2.0.2] - 04/10/2024
+
+### Fixed
+- Hotfix, commas missing from config file
+
+## [v2.0.1] - 03/10/2024
 
 ### Added
-
 - Update config for CRM now going into SVD
 - Update min and max variants in FH config
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ It contains all changes from 2024-07-09 onwards
 
 ### Fixed
 - Hotfix, commas missing from config file
+- Hotfix, BRCA does not produce _intersect.txt
 
 ## [v2.0.1] - 03/10/2024
 

--- a/config/config_gen01.yaml
+++ b/config/config_gen01.yaml
@@ -15,8 +15,8 @@ pipelines:
                   '*_QC.txt',
                   '*_filtered_meta_annotated.vcf',
                   '*_cosmic.csv',
-                  '*_intersect.txt'
-                  'hotspot_coverage'
+                  '*_intersect.txt',
+                  'hotspot_coverage',
                   '1_SomaticAmplicon.sh.e*'
                   ]
     sample_not_expected_files: ['*_fastqc.zip']

--- a/config/config_gen01.yaml
+++ b/config/config_gen01.yaml
@@ -38,7 +38,6 @@ pipelines:
                   '*_QC.txt',
                   '*_filtered_meta_annotated.vcf',
                   '*_cosmic.csv',    
-                  '*_intersect.txt',
                   'hotspot_coverage',
                   '1_SomaticAmplicon.sh.e*'
                   ]


### PR DESCRIPTION
Hotfix to config for updated BRCA/CRM - added in commas to CRM and removed _intersect.txt from BRCA required files as this is not produced by the pipeline.

There's still an issue with the NTC not producing the required files which I've fixed for this run by creating blank files - will discuss with Erik whether this should be a pipeline or autoQC fix.