### PR TITLE
ordered samplesheets by date

### DIFF
--- a/sample_sheet/views.py
+++ b/sample_sheet/views.py
@@ -184,7 +184,7 @@ def view_worksheets(request, service_slug):
 	assay = get_object_or_404(Assay, assay_slug = service_slug)
 
 	# get all worksheets from selected service
-	worksheets = Worksheet.objects.filter(worksheet_test = assay).order_by('-worksheet_id')
+	worksheets = Worksheet.objects.filter(worksheet_test = assay).order_by('-upload_date')
 
 	ws_list = []
 


### PR DESCRIPTION
Tiny code review: Currently the samplesheets are ordered reverse alphabetically by worksheet ID but that means that the most recent is not at the top (eg. 24-999 is above 24-2345 in the table).
Changed ordering to be reverse upload date so most recent is first.