### PR TITLE
Issue 224 : Stop too many FastWGS

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,2 @@
+python manage.py update_database --raw_data_dir /media/joseph/Storage/data/archive/nextseq \
+								--config config/config_local.yaml

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import os
 
-deploy_location = 'local'
+deploy_location = 'webserver'
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import os
 
-deploy_location = 'webserver'
+deploy_location = 'local'
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/qc_database/utils/kpi.py
+++ b/qc_database/utils/kpi.py
@@ -65,14 +65,15 @@ def make_kpi_excel(runs):
     panels = {
         'NGHS-102X': 'BRCA',
         'NGHS-101X': 'CRM',
-        'SMP2v3': 'CRUK',
-        'AgilentOGTFH': 'FH',
-        'TruSightMyeloid': 'Myeloid',
-        'NIPT': 'NIPT',
-        'RochePanCancer': 'PanCan',
-        'IlluminaTruSightOne': 'TSO',
+        'AgilentOGTFH': 'A_FH',
+        'TSO500_DNA': 'TSO500_DNA',
+        'TSO500_RNA': 'TSO500_RNA',
         'IlluminaTruSightCancer': 'TSC',
-        'NexteraDNAFlex': 'WGS'
+        'ctDNA': 'ctDNA',
+        'FastWGS': 'FastWGS',
+        'WGS': 'WGS',
+        'NonacusFH': 'NonacusFH',
+        'NonocusWES38': 'NonacusWES38'
     }
     
     # create sheet for each panel in panel dictionary

--- a/sample_sheet/example_shire_queries/wgs_pcrfree_shire_query_2.csv
+++ b/sample_sheet/example_shire_queries/wgs_pcrfree_shire_query_2.csv
@@ -1,0 +1,16 @@
+LABNO,POSITION,WORKSHEET,TEST,COMMENTS,UPDATEDDATE,REASON_FOR_REFERRAL,FIRSTNAME,LASTNAME,SEX
+20M66521,1,20-0872,WGS - Illumina PCR Free,,01-Oct-21,PANEL WGS ID,Female Infant,Dillan,F
+20M66543,2,20-0872,WGS - Illumina PCR Free,,01-Oct-21,PANEL WGS ID,Bob,Dillan,M
+20M66889,3,20-0872,WGS - Illumina PCR Free,,01-Oct-21,PANEL WGS CongenAnom,Mary,Dillan,F
+sample2,4,20-0872,WGS - Illumina PCR Free,,01-Oct-21,PANEL WGS ID,Female Infant,Dillan,F
+sample3,5,20-0872,WGS - Illumina PCR Free,,01-Oct-21,PANEL WGS ID,Bob,Dillan,M
+sample4,6,20-0872,WGS - Illumina PCR Free,,01-Oct-21,PANEL WGS CongenAnom,Mary,Dillan,F
+sample5,7,20-0872,WGS - Illumina PCR Free,,01-Oct-21,PANEL WGS ID,Female Infant,Dillan,F
+sample6,8,20-0872,WGS - Illumina PCR Free,,01-Oct-21,PANEL WGS ID,Bob,Dillan,M
+sample7,9,20-0872,WGS - Illumina PCR Free,,01-Oct-21,PANEL WGS CongenAnom,Mary,Dillan,F
+sample8,10,20-0872,WGS - Illumina PCR Free,,01-Oct-21,PANEL WGS ID,Female Infant,Dillan,F
+sample9,11,20-0872,WGS - Illumina PCR Free,,01-Oct-21,PANEL WGS ID,Bob,Dillan,M
+sample10,12,20-0872,WGS - Illumina PCR Free,,01-Oct-21,PANEL WGS CongenAnom,Mary,Dillan,F
+sample11,13,20-0872,WGS - Illumina PCR Free,,01-Oct-21,PANEL WGS ID,Female Infant,Dillan,F
+sample12,14,20-0872,WGS - Illumina PCR Free,,01-Oct-21,PANEL WGS ID,Bob,Dillan,M
+sample13,15,20-0872,WGS - Illumina PCR Free,,01-Oct-21,PANEL WGS CongenAnom,Mary,Dillan,F

--- a/sample_sheet/forms.py
+++ b/sample_sheet/forms.py
@@ -214,6 +214,32 @@ class ClearFamilyForm(forms.Form):
 				)
 
 
+class ClearUrgentForm(forms.Form):
+	clear_urgent_check = forms.BooleanField(required=False, label = 'I am sure.')
+
+	def __init__(self, *args, **kwargs):
+		self.worksheet_obj = kwargs.pop('worksheet_obj')
+		super(ClearUrgentForm, self).__init__(*args, **kwargs)
+		self.helper = FormHelper()
+		self.fields['clear_urgent_check'].initial = False
+		self.helper.form_id = 'clear-urgent-form'
+		self.helper.form_method = 'POST'
+		self.helper.layout = Layout(
+			Div(
+				Div(
+					Field('clear_urgent_check'),
+						style="text-align: center"
+					),
+				Div(
+					ButtonHolder(
+						Submit('submit', 'Clear urgent data', css_class='btn btn-danger w-25')
+						),
+						style="text-align: center"
+					)
+					),
+				)
+
+
 class ClinSciSignoffForm(forms.Form):
 
 	clinsci_worksheet_checked = forms.BooleanField(required=False, label = 'Manual check')

--- a/sample_sheet/templates/sample_sheet/worksheet_base.html
+++ b/sample_sheet/templates/sample_sheet/worksheet_base.html
@@ -15,6 +15,15 @@
             <br>
             <br>
             <h3>{{ worksheet_info.assay_name }} Worksheet {{ worksheet_info.worksheet_id }}</h3>
+            {% if messages %}
+            <div class="messages">
+                {% for message in messages %}
+                    <div class="alert alert-{{ message.tags }}">
+                        {{ message }}
+                    </div>
+                {% endfor %}
+            </div>
+            {% endif %}
             <br>
             <br>
         </div>

--- a/sample_sheet/templates/sample_sheet/worksheet_clinsci.html
+++ b/sample_sheet/templates/sample_sheet/worksheet_clinsci.html
@@ -98,12 +98,10 @@
             {% endif %}
             {% endif %}
 
-            {% if "NTC" in sample.sample %}
-            <td></td>
-            {% endif %}
+
 
             <!-- if signed off then remove buttons -->
-            {% if worksheet_info.clinsci_signoff_complete %}
+            {% if 'NTC' in sample.sample or worksheet_info.clinsci_signoff_complete %}
             <td></td>
             {% else %}
             <td style="text-align:right" data-bs-toggle="modal" data-bs-target="#edit-sample-{{ pos }}">

--- a/sample_sheet/templates/sample_sheet/worksheet_clinsci.html
+++ b/sample_sheet/templates/sample_sheet/worksheet_clinsci.html
@@ -90,11 +90,16 @@
 
             <!-- formatting for urgent column -->
             {% if worksheet_info.assay_name in "WGS WINGS" %}
+            <!-- and "NTC" in sample.sample_obj.sampleid -->
             {% if sample.sample_obj.urgent %}
               <td>Yes</td>
             {% else %}
               <td>-</td>
             {% endif %}
+            {% endif %}
+
+            {% if "NTC" in sample.sample %}
+            <td></td>
             {% endif %}
 
             <!-- if signed off then remove buttons -->
@@ -108,8 +113,11 @@
             </td>           
             {% endif %}
 
+
           </tr>
           {% endfor %}
+
+
 
         </tbody>
       </table>
@@ -130,6 +138,12 @@
           <button data-bs-toggle="modal" data-bs-target="#clear-family" class="btn btn-danger btn-sm">
             <span class="fa fa-users-slash" style="width: 20px; color: white;"></span>
             Clear family
+          </button>
+        </div>
+        <div class = "col-3">
+          <button data-bs-toggle="modal" data-bs-target="#clear-urgent" class="btn btn-danger btn-sm">
+            <span class="fa fa-exclamation-slash" style="width: 20px; color: white;"></span>
+            Clear urgent
           </button>
         </div>
       </div>
@@ -224,6 +238,24 @@
         <h5><center>Warning: This will remove all family data from this worksheet.</center></h5>
 
         {% crispy clear_family_form %}
+
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- remove urgent data -->
+<div class="modal fade" id="clear-urgent" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-header" style="background-color: #3AA7A9; color: white;">
+        <h5>Clear urgent information</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <h5><center>Warning: This will remove all Urgent from this worksheet.</center></h5>
+
+        {% crispy clear_urgent_form %}
 
       </div>
     </div>

--- a/sample_sheet/views.py
+++ b/sample_sheet/views.py
@@ -496,8 +496,8 @@ def view_worksheet_samples(request, service_slug, worksheet_id):
 					sl_not_ntc = [i for i in sample_list if "NTC" not in i]
 					urgent_sample_list = [context["sample_data"][sample]["sample"] for sample in context["sample_data"] if context["sample_data"][sample]["sample_obj"].urgent == True]
 					urgent_sample_list = [i for i in urgent_sample_list if "NTC" not in i]
-					ntc = SampleToWorksheet.objects.filter(worksheet=sample_ws_obj.worksheet, sample__sampleid__startswith=ntc_string)
-
+					ntc = SampleToWorksheet.objects.filter(worksheet=sample_ws_obj.worksheet, sample__sampleid__startswith=ntc_string)[0]
+					
 					# count : number of samples in this worksheet, new number of urgent samples and proportion urgent
 					number_samples = len(sl_not_ntc)				
 					number_urgent_samples = len(urgent_sample_list)
@@ -539,17 +539,17 @@ def view_worksheet_samples(request, service_slug, worksheet_id):
 						sample_ws_obj.save()
 					
 					# set NTC as urgent if any samples urgent
+					print(f"number of urgent samples = {number_urgent_samples}")
 					if number_urgent_samples > 0 :
 						
 						print("INFO: number of urgent samples greater than 0, setting NTC to Urgent")
-						ntc[0].urgent = True
-						ntc[0].save()
-					
+						ntc.urgent = True
+						ntc.save()
 					else:
 						
 						print("INFO: number of urgent samples 0, setting NTC to not urgent")
-						ntc[0].urgent = False
-						ntc[0].save()
+						ntc.urgent = False
+						ntc.save()
 						
 				## edit referral if changed
 				if cleaned_data['referral_type'] != sample_ws_obj.referral:

--- a/sample_sheet/views.py
+++ b/sample_sheet/views.py
@@ -518,14 +518,14 @@ def view_worksheet_samples(request, service_slug, worksheet_id):
 														
 					if number_urgent_samples > max_urgent or prop_urgent > max_prop_urgent:
 						
-						print(f"INFO: number urgent samples greater than max number ({max_urgent})")
-						
 						if number_urgent_samples > max_urgent:
 							
+							print(f"INFO: number urgent samples greater than max number ({max_urgent})")
 							messages.warning(request, "Sorry, can't have more than 6 urgent samples per run")
 						
 						if prop_urgent > max_prop_urgent:
 							
+							print(f"INFO: number urgent samples greater than max proportion of urgent samples (1/3rd)")
 							messages.warning(request, "Sorry, can't have more than 1/3rd of samples set as urgent")
 
 						if sample_ws_obj.sample.familyid:
@@ -537,6 +537,7 @@ def view_worksheet_samples(request, service_slug, worksheet_id):
 						
 						sample_ws_obj.urgent = False
 						sample_ws_obj.save()
+						number_urgent_samples = number_urgent_samples - urgency_modifier
 					
 					# set NTC as urgent if any samples urgent
 					print(f"number of urgent samples = {number_urgent_samples}")


### PR DESCRIPTION
- number of urgent samples that can be added to WGS now limited to 6 or 1/3rd of samples
- added a button to clinical checks tab to reset all urgent to false
- removed button to set the urgency of NTC, this is now determined automatically
Closes #224 