### PR TITLE
Hot fix for nan values in coverage. Closes #253

### DIFF
--- a/pipelines/parsers.py
+++ b/pipelines/parsers.py
@@ -893,6 +893,11 @@ def parse_dragen_wgs_coverage_metrics_file(dragen_wgs_coverage_metrics_file):
 			new_key = new_key.replace('1x3x', '1x_3x')
 
 			new_key = new_key.replace('0x1x', '0x_1x')
+
+			# Replace any NaN value to a decimal, as that's what the models need
+			if value == "nan":
+
+				value = 0.0
 			
 			if prefix == 'COVERAGE SUMMARY':
 								


### PR DESCRIPTION
Bug fix which Closes #253 

250725_A00748_0727_AHWYVMDRX5 had a nan value in the wgs coverage metrics for the NTC. This wouldn't upload to the database as the models expect a decimal. Little fix to change any nan to 0 before upload. 